### PR TITLE
Better timeout handling

### DIFF
--- a/builder/pip.py
+++ b/builder/pip.py
@@ -1,9 +1,9 @@
 """Pip build commands."""
 import os
-import subprocess
-import sys
 from pathlib import Path
 from typing import List, Optional
+
+from .utils import run_command
 
 
 def build_wheels_package(
@@ -24,12 +24,8 @@ def build_wheels_package(
     # Add constraint
     constraint_cmd = f"--constraint {constraint}" if constraint else ""
 
-    subprocess.run(
+    run_command(
         f'pip3 wheel --progress-bar off --no-binary "{skip_binary}" --wheel-dir {output} --find-links {index} {constraint_cmd} "{package}"',
-        shell=True,
-        check=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
         env=build_env,
         timeout=timeout,
     )
@@ -53,12 +49,8 @@ def build_wheels_requirement(
     # Add constraint
     constraint_cmd = f"--constraint {constraint}" if constraint else ""
 
-    subprocess.run(
+    run_command(
         f'pip3 wheel --progress-bar off --no-binary "{skip_binary}" --wheel-dir {output} --find-links {index} {constraint_cmd} --requirement {requirement}',
-        shell=True,
-        check=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
         env=build_env,
         timeout=timeout,
     )
@@ -72,12 +64,8 @@ def build_wheels_local(index: str, output: Path) -> None:
     build_env = os.environ.copy()
     build_env["MAKEFLAGS"] = f"-j{cpu}"
 
-    subprocess.run(
+    run_command(
         f"pip3 wheel --progress-bar off --wheel-dir {output} --find-links {index} .",
-        shell=True,
-        check=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
         env=build_env,
     )
 
@@ -118,10 +106,6 @@ def install_pips(index: str, pips: str) -> None:
     """Install all pipy string formated as 'package1;package2'."""
     packages = " ".join(pips.split(";"))
 
-    subprocess.run(
+    run_command(
         f"pip install --progress-bar off --upgrade --no-cache-dir --prefer-binary --find-links {index} {packages}",
-        shell=True,
-        check=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
     )

--- a/builder/upload/rsync.py
+++ b/builder/upload/rsync.py
@@ -1,7 +1,5 @@
 """Upload plugin rsync."""
 from pathlib import Path
-import subprocess
-import sys
 
 from ..utils import run_command
 

--- a/builder/upload/rsync.py
+++ b/builder/upload/rsync.py
@@ -3,13 +3,11 @@ from pathlib import Path
 import subprocess
 import sys
 
+from ..utils import run_command
+
 
 def upload(local: Path, remote: str) -> None:
     """Upload wheels from folder to remote rsync server."""
-    subprocess.run(
+    run_command(
         f"rsync --human-readable --recursive --partial --progress --checksum {local}/* {remote}/",
-        shell=True,
-        check=True,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
     )

--- a/builder/utils.py
+++ b/builder/utils.py
@@ -50,11 +50,12 @@ def run_command(
     try:
         process.communicate(timeout=timeout)
     except subprocess.TimeoutExpired as err:
-        print(f"Timeout for {cmd}", flash=True)
+        print(f"Timeout for '{cmd}'", flash=True)
         process.kill()
         raise err
 
     # Process return code
     if process.returncode == 0:
         return
+    print(f"Command '{cmd}' return error {process.returncode}", flash=True)
     raise subprocess.CalledProcessError(process.returncode, cmd)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "1.12.0"
+VERSION = "1.12.1"
 
 setup(
     name="builder",


### PR DESCRIPTION
```
The timeout argument is passed to Popen.communicate(). If the timeout expires, the child process will be killed and waited for. The TimeoutExpired exception will be re-raised after the child process has terminated.
```

This block with qemu. I reimplement `run` but make sure we don't block until the pip job is killed