### PR TITLE
Revert "Bump numpy from 1.21.2 to 1.22.0"

### DIFF
--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,4 @@
 Cython==0.29.26
-numpy==1.22.0
+numpy==1.21.2
 scikit-build==0.12.0
 cffi==1.15.0


### PR DESCRIPTION
Reverts home-assistant/wheels#307

Reverting since it appears to break the build process from discussion in https://github.com/home-assistant/wheels/pull/311
e.g. https://github.com/home-assistant/wheels/runs/4764481586?check_suite_focus=true
```
  error: Command "gcc -shared -Wl,--strip-all build/temp.linux-x86_64-3.8/build/src.linux-x86_64-3.8/numpy/core/src/umath/loops_unary_fp.dispatch.sse41.o .... -lnpymath -o build/lib.linux-x86_64-3.8/numpy/core/_multiarray_umath.cpython-38-i386-linux-gnu.so" failed with exit status 1
```