### PR TITLE
Add command line flag to avoid overwriting grpc wheels

### DIFF
--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -141,7 +141,8 @@ def builder(
             skip_binary = check_available_binary(
                 wheels_index,
                 skip_binary,
-                packages + constraints,
+                packages,
+                constraints,
             )
             for package in packages:
                 print(f"Process package: {package}", flush=True)
@@ -169,7 +170,8 @@ def builder(
             skip_binary = check_available_binary(
                 wheels_index,
                 skip_binary,
-                packages + constraints,
+                packages,
+                constraints,
             )
             try:
                 build_wheels_requirement(

--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -41,7 +41,9 @@ from builder.wheel import copy_wheels_from_cache, fix_wheels_name, run_auditwhee
     "--skip-binary", default=":none:", help="List of packages to skip wheels from pypi."
 )
 @click.option(
-    "--skip-exists", default="", help="List of packages to skip upload/rsync if already exist in remote wheels repository."
+    "--skip-exists",
+    default="",
+    help="List of packages to skip upload/rsync if already exist in remote wheels repository.",
 )
 @click.option(
     "--requirement",
@@ -196,7 +198,9 @@ def builder(
             # When --skip-binary and --skip-exists are set a wheel is only built from source once.
             packages = extract_packages(requirement, requirement_diff)
             constraints = parse_requirements(constraint) if constraint else []
-            remove_local_wheels(wheels_index, skip_exists.split(","), packages + constraints, wheels_dir)
+            remove_local_wheels(
+                wheels_index, skip_exists.split(","), packages + constraints, wheels_dir
+            )
 
         if not test:
             run_upload(upload, output, remote)

--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -41,11 +41,6 @@ from builder.wheel import copy_wheels_from_cache, fix_wheels_name, run_auditwhee
     "--skip-binary", default=":none:", help="List of packages to skip wheels from pypi."
 )
 @click.option(
-    "--skip-exists",
-    default="",
-    help="List of packages to skip upload/rsync if already exist in remote wheels repository.",
-)
-@click.option(
     "--requirement",
     type=click_pathlib.Path(exists=True),
     help="Python requirement file.",
@@ -95,7 +90,6 @@ def builder(
     pip: str,
     index: str,
     skip_binary: str,
-    skip_exists: str,
     requirement: Optional[Path],
     requirement_diff: Optional[Path],
     constraint: Optional[Path],
@@ -194,14 +188,14 @@ def builder(
 
         fix_wheels_name(wheels_dir)
 
-        if skip_exists:
+        if skip_binary != ":none:":
             # Some wheels that already exist should not be overwritten in case we replace with
             # a wheel that came from pypi rather than a wheel built from source with extra flags.
             # When --skip-binary and --skip-exists are set a wheel is only built from source once.
             packages = extract_packages(requirement, requirement_diff)
             constraints = parse_requirements(constraint) if constraint else []
             remove_local_wheels(
-                wheels_index, skip_exists.split(","), packages + constraints, wheels_dir
+                wheels_index, skip_binary.split(","), packages + constraints, wheels_dir
             )
 
         if not test:

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -46,9 +46,7 @@ def check_existing_packages(index: str, package_map: Dict[str, str]) -> Set[str]
     return found
 
 
-def check_available_binary(
-    index: str, skip_binary: str, packages: List[str]
-) -> str:
+def check_available_binary(index: str, skip_binary: str, packages: List[str]) -> str:
     """Check if binary exists and ignore this skip."""
     if skip_binary == ":none:":
         return skip_binary
@@ -62,7 +60,10 @@ def check_available_binary(
     binary_package_map = {}
     for binary in list_binary:
         if not (package := package_map.get(binary)):
-            print(f"Skip binary '{binary}' not in packages/constraints; Can't determine desired version", flush=True)
+            print(
+                f"Skip binary '{binary}' not in packages/constraints; Can't determine desired version",
+                flush=True,
+            )
             continue
         binary_package_map[binary] = package
 
@@ -80,11 +81,16 @@ def check_available_binary(
 
 
 def remove_local_wheels(
-    index: str, skip_exists: List[str], packages: List[str], wheels_dir: Path,
+    index: str,
+    skip_exists: List[str],
+    packages: List[str],
+    wheels_dir: Path,
 ) -> str:
     """Remove existing wheels if they already exist in the index to avoid syncing."""
     package_map = create_package_map(packages)
-    binary_package_map = {name: package_map[name] for name in skip_exists if name in package_map}
+    binary_package_map = {
+        name: package_map[name] for name in skip_exists if name in package_map
+    }
     print(f"Checking if binaries already exist for packages {binary_package_map}")
     exists = check_existing_packages(index, binary_package_map)
     for binary in exists:

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -46,7 +46,9 @@ def check_existing_packages(index: str, package_map: Dict[str, str]) -> Set[str]
     return found
 
 
-def check_available_binary(index: str, skip_binary: str, packages: List[str], constraints: List[str]) -> str:
+def check_available_binary(
+    index: str, skip_binary: str, packages: List[str], constraints: List[str]
+) -> str:
     """Check if binary exists and ignore this skip."""
     if skip_binary == ":none:":
         return skip_binary

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -46,7 +46,7 @@ def check_existing_packages(index: str, package_map: Dict[str, str]) -> Set[str]
     return found
 
 
-def check_available_binary(index: str, skip_binary: str, packages: List[str]) -> str:
+def check_available_binary(index: str, skip_binary: str, packages: List[str], constraints: List[str]) -> str:
     """Check if binary exists and ignore this skip."""
     if skip_binary == ":none:":
         return skip_binary
@@ -54,7 +54,7 @@ def check_available_binary(index: str, skip_binary: str, packages: List[str]) ->
     list_binary = skip_binary.split(",")
 
     # Map of package basename to the desired package version
-    package_map = create_package_map(packages)
+    package_map = create_package_map(packages + constraints)
 
     # View of package map limited to packages in --skip-binary
     binary_package_map = {}

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -23,8 +23,31 @@ def create_wheels_index(base_index: str) -> str:
     return f"{base_index}/{alpine_version()}/{build_arch()}/"
 
 
+def create_package_map(packages: list[str]) -> dict[str, str]:
+    """Create a dictionary from package base name to package and version string."""
+    results = {}
+    for package in packages.copy():
+        find = _RE_REQUIREMENT.match(package)
+        if not find:
+            continue
+        package = find["package"]
+        version = find["version"]
+        results[package] = f"{package}-{version}"
+    return results
+
+
+def check_existing_packages(index: str, package_map: dict[str, str]) -> Set[str]:
+    """Return the set of package names that already exist in the index."""
+    available_data = requests.get(index, allow_redirects=True).text
+    found: Set[str] = set({})
+    for (binary, package) in package_map.items():
+        if package in available_data:
+            found.add(binary)
+    return found
+
+
 def check_available_binary(
-    index: str, skip_binary: str, packages: List[str], constraints: List[str]
+    index: str, skip_binary: str, packages: List[str]
 ) -> str:
     """Check if binary exists and ignore this skip."""
     if skip_binary == ":none:":
@@ -33,31 +56,41 @@ def check_available_binary(
     list_binary = skip_binary.split(",")
     available_data = requests.get(index, allow_redirects=True).text
 
-    list_needed: Set[str] = set()
+    # Map of package basename to the desired package version
+    package_map = create_package_map(packages)
+
+    # View of package map limited to packages in --skip-binary
+    binary_package_map = {}
     for binary in list_binary:
-        for package in packages + constraints:
-            if not package.startswith(binary):
-                continue
+        if not (package := package_map.get(binary)):
+            print(f"Skip binary '{binary}' not in packages/constraints; Can't determine desired version", flush=True)
+            continue
+        binary_package_map[binary] = package
 
-            # Check more details
-            find = _RE_REQUIREMENT.match(package)
-            if not find:
-                raise ValueError(f"package requirement malformed: {package}")
-
-            # Check full name
-            if binary != find["package"]:
-                continue
-
-            # Process packages
-            name = f"{binary}-{find['version']}"
-            if name in available_data:
-                continue
-
-            # Ignore binary
-            print(f"Ignore Binary {package}: {name}", flush=True)
-            list_needed.add(binary)
+    print(f"Checking if binaries already exist for packages {binary_package_map}")
+    list_found: Set[str] = check_existing_packages(index, binary_package_map)
+    print(f"Packages already exist: {list_found}")
+    list_needed = binary_package_map.keys() - list_found
 
     # Generate needed list of skip binary
     if not list_needed:
         return ":none:"
+
+    print(f"Will force binary build for {list_needed}")
     return ",".join(list_needed)
+
+
+def remove_local_wheels(
+    index: str, skip_exists: list[str], packages: List[str], wheels_dir: Path,
+) -> str:
+    """Remove existing wheels if they already exist in the index to avoid syncing."""
+    package_map = create_package_map(packages)
+    binary_package_map = {name: package_map[name] for name in skip_exists if name in package_map}
+    print(f"Checking if binaries already exist for packages {binary_package_map}")
+    exists = check_existing_packages(index, binary_package_map)
+    for binary in exists:
+        package = binary_package_map[binary]
+        print(f"Found existing wheels for {binary}, removing local copy {package}")
+        for wheel in wheels_dir.glob(f"{package}-*.whl"):
+            print(f"Removing local wheel {wheel}")
+            wheel.unlink()

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -54,7 +54,6 @@ def check_available_binary(
         return skip_binary
 
     list_binary = skip_binary.split(",")
-    available_data = requests.get(index, allow_redirects=True).text
 
     # Map of package basename to the desired package version
     package_map = create_package_map(packages)

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -1,7 +1,7 @@
 """Create folder structure for index."""
 from pathlib import Path
 import re
-from typing import List, Set
+from typing import List, Set, Dict
 
 import requests
 
@@ -23,7 +23,7 @@ def create_wheels_index(base_index: str) -> str:
     return f"{base_index}/{alpine_version()}/{build_arch()}/"
 
 
-def create_package_map(packages: list[str]) -> dict[str, str]:
+def create_package_map(packages: List[str]) -> Dict[str, str]:
     """Create a dictionary from package base name to package and version string."""
     results = {}
     for package in packages.copy():
@@ -36,7 +36,7 @@ def create_package_map(packages: list[str]) -> dict[str, str]:
     return results
 
 
-def check_existing_packages(index: str, package_map: dict[str, str]) -> Set[str]:
+def check_existing_packages(index: str, package_map: Dict[str, str]) -> Set[str]:
     """Return the set of package names that already exist in the index."""
     available_data = requests.get(index, allow_redirects=True).text
     found: Set[str] = set({})
@@ -81,7 +81,7 @@ def check_available_binary(
 
 
 def remove_local_wheels(
-    index: str, skip_exists: list[str], packages: List[str], wheels_dir: Path,
+    index: str, skip_exists: List[str], packages: List[str], wheels_dir: Path,
 ) -> str:
     """Remove existing wheels if they already exist in the index to avoid syncing."""
     package_map = create_package_map(packages)

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -42,6 +42,7 @@ def test_check_available_binary_none() -> None:
                 "aiohttp==3.7.4",
                 "google_cloud_pubsub==2.1.0",
             ],
+            constraints=[],
         )
         == ":none:"
     )
@@ -57,6 +58,7 @@ def test_check_available_binary_all() -> None:
                 "aiohttp==3.7.4",
                 "google_cloud_pubsub==2.1.0",
             ],
+            constraints=[],
         )
         == ":none:"
     )
@@ -72,6 +74,7 @@ def test_check_available_binary_version_present() -> None:
                 "aiohttp==3.7.4",
                 "google_cloud_pubsub==2.1.0",
             ],
+            constraints=[],
         )
         == ":none:"
     )
@@ -87,6 +90,7 @@ def test_check_available_binary_version_missing() -> None:
                 "aiohttp==3.7.5",  # Not in the index
                 "google_cloud_pubsub==2.1.0",
             ],
+            constraints=[],
         )
         == "aiohttp"
     )
@@ -102,6 +106,7 @@ def test_check_available_binary_implicit_dep_skipped() -> None:
                 "aiohttp==3.7.4",
                 "google_cloud_pubsub==2.1.0",
             ],
+            constraints=[],
         )
         == ":none:"
     )
@@ -116,6 +121,8 @@ def test_check_available_binary_skip_constraint() -> None:
             packages=[
                 "aiohttp==3.7.4",
                 "google_cloud_pubsub==2.1.0",
+            ],
+            constraints=[
                 "grpcio==1.31.0",  # Already exists in index
             ],
         )
@@ -132,6 +139,8 @@ def test_check_available_binary_for_missing_constraint() -> None:
             packages=[
                 "aiohttp==3.7.4",
                 "google_cloud_pubsub==2.1.0",
+            ],
+            constraints=[
                 "grpcio==1.43.0",  # Not in index
             ],
         )

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -151,10 +151,10 @@ def test_remove_local_wheel(tmppath: Path) -> None:
     p.touch()
     p = tmppath / "grpcio-1.31.0-cp39-none-any.whl"
     p.touch()
-    assert [ p.name for p in tmppath.glob("*.whl") ] == [
+    assert { p.name for p in tmppath.glob("*.whl") } == {
         "grpcio-1.31.0-cp39-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
-    ]
+    }
 
     remove_local_wheels(
         TEST_INDEX_URL,
@@ -167,9 +167,9 @@ def test_remove_local_wheel(tmppath: Path) -> None:
     )
 
     # grpc is removed
-    assert [ p.name for p in tmppath.glob("*.whl") ] == [
+    assert { p.name for p in tmppath.glob("*.whl") } == {
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
-    ]
+    }
 
 
 def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
@@ -179,10 +179,10 @@ def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
     p.touch()
     p = tmppath / "grpcio-1.43.0-cp39-none-any.whl"
     p.touch()
-    assert [ p.name for p in tmppath.glob("*.whl") ] == [
+    assert { p.name for p in tmppath.glob("*.whl") } == {
         "grpcio-1.43.0-cp39-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
-    ]
+    }
 
     remove_local_wheels(
         TEST_INDEX_URL,
@@ -195,8 +195,8 @@ def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
     )
 
     # grpc is removed
-    assert [ p.name for p in tmppath.glob("*.whl") ] == [
+    assert set([ p.name for p in tmppath.glob("*.whl") ]) == {
         "grpcio-1.43.0-cp39-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
-    ]
+    }
 

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -199,4 +199,3 @@ def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
         "grpcio-1.43.0-cp39-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
-

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -151,7 +151,7 @@ def test_remove_local_wheel(tmppath: Path) -> None:
     p.touch()
     p = tmppath / "grpcio-1.31.0-cp39-none-any.whl"
     p.touch()
-    assert { p.name for p in tmppath.glob("*.whl") } == {
+    assert {p.name for p in tmppath.glob("*.whl")} == {
         "grpcio-1.31.0-cp39-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
@@ -167,7 +167,7 @@ def test_remove_local_wheel(tmppath: Path) -> None:
     )
 
     # grpc is removed
-    assert { p.name for p in tmppath.glob("*.whl") } == {
+    assert {p.name for p in tmppath.glob("*.whl")} == {
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
 
@@ -179,7 +179,7 @@ def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
     p.touch()
     p = tmppath / "grpcio-1.43.0-cp39-none-any.whl"
     p.touch()
-    assert { p.name for p in tmppath.glob("*.whl") } == {
+    assert {p.name for p in tmppath.glob("*.whl")} == {
         "grpcio-1.43.0-cp39-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
@@ -195,7 +195,7 @@ def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
     )
 
     # grpc is removed
-    assert set([ p.name for p in tmppath.glob("*.whl") ]) == {
+    assert {p.name for p in tmppath.glob("*.whl")} == {
         "grpcio-1.43.0-cp39-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }


### PR DESCRIPTION
grpcio armv7 wheels are broken again, due to this behavior:
- First time a new grpc version exists, its built from source due to --skip_binary=grpc (after #311 and https://github.com/home-assistant/core/pull/63521). Great.
- Second time a build happens (for another package bump) grpc is in the index then grpc is removed from --skip_binary to get it to use an existing wheel, but then it uses the pypi wheel rather than the home assistant index wheel (https://github.com/pypa/pip/issues/4321). Bad!

To remedy, add a new flag --skip_exists that will remove the local grpc wheel when it already exists in the index before syncing.

This change refactors existing code in `check_available_binary` to take advantage of its existing test coverage, but it makes the change bigger than to needs to be.

Assuming this direction is good, the rollout steps are:
- Release a new wheel
- Update core to set --skip_exists=grpcio
- Remove the existing 1.43.0 wheel for armv7
- Bump something
- Bump something else again to verify the fix worked.