### PR TITLE
Revert "Bump cmake from 3.22.2 to 3.25.2"

### DIFF
--- a/requirements_cp310.txt
+++ b/requirements_cp310.txt
@@ -2,4 +2,4 @@ Cython==0.29.33
 numpy==1.22.4
 scikit-build==0.16.7
 cffi==1.15.1
-cmake==3.25.2
+cmake==3.22.2


### PR DESCRIPTION
Reverts home-assistant/wheels#502

We need to revert this one for now, as it breaks our CI at this moment.

