### PR TITLE
Fix deprecated command `set-output` in workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,10 +47,10 @@ jobs:
             docker+=("--cache-from $name:dev")
           fi
 
-          echo "::set-output name=name::$name"
-          echo "::set-output name=version::$version"
-          echo "::set-output name=base::$base"
-          echo "::set-output name=docker::${docker[@]}"
+          echo "name=$name" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "base=$base" >> $GITHUB_OUTPUT
+          echo "docker=${docker[@]}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,7 +33,7 @@ jobs:
 
           echo Current version:    $latest
           echo New target version: $datepre.$newpost
-          echo "::set-output name=version::$datepre.$newpost"
+          echo "version=$datepre.$newpost" >> $GITHUB_OUTPUT
 
       - name: Run Release Drafter
         uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
Fix deprecated command `set-output` in workflows