### PR TITLE
Fix use ${{ github.action_path }} to ${GITHUB_ACTION_PATH} with bash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
     - shell: bash
       id: version
       run: |
-        input=$(echo "${{ github.action_path }}" | cut -d"/" -f8 )
+        input="${GITHUB_ACTION_PATH##*/}"
         if [[ "${input}" == "master" ]] || [[ -z "${input}" ]]; then
           input="dev"
         fi


### PR DESCRIPTION
Fix use ${{ github.action_path }} to ${GITHUB_ACTION_PATH} with bash pattern matching {##*/}

Issue: https://github.com/actions/runner/issues/716