### PR TITLE
Update pip to 23.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ click-pathlib==2020.3.13.0
 requests==2.28.2
 wheel==0.40.0
 setuptools==67.6.1
-pip==22.3
+pip==23.1


### PR DESCRIPTION
Updates `pip` to 23.1

<https://pip.pypa.io/en/stable/news/#v23-1>