### PR TITLE
Remove cmake from Python requirements

### DIFF
--- a/requirements_cp311.txt
+++ b/requirements_cp311.txt
@@ -2,4 +2,3 @@ Cython==0.29.34
 numpy==1.24.2
 scikit-build==0.17.1
 cffi==1.15.1
-cmake==3.22.2


### PR DESCRIPTION
Originally added in #448

Seems no longer needed, and we can use the (newer) version provided by Alpine instead. Going to remove it for ABI cp311 only.

This gives us the opportunity to test building all wheels, without harming/touching our current production.

CI: Is expected to fail (chicken-egg problem, as we don't have all images build on the `dev` branch yet).