### PR TITLE
Use pep 503 compatible wheels index for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN \
     && pip3 install --no-cache-dir \
         -r /usr/src/requirements.txt \
         -r /usr/src/requirements_${CPYTHON_ABI}.txt \
-        --find-links "https://wheels.home-assistant.io/musllinux/" \
+        --extra-index-url "https://wheels.home-assistant.io/musllinux-index/" \
     && rm -rf /usr/src/*
 
 # Install auditwheel

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -40,7 +40,7 @@ def create_wheels_folder(base_folder: Path) -> Path:
 
 def create_wheels_index(base_index: str) -> str:
     """Create wheels specific URL."""
-    return f"{base_index}/{_MUSLLINUX}/"
+    return f"{base_index}/{_MUSLLINUX}-index/"
 
 
 def create_package_map(packages: List[str]) -> Dict[str, AwesomeVersion]:

--- a/builder/pip.py
+++ b/builder/pip.py
@@ -25,7 +25,7 @@ def build_wheels_package(
     constraint_cmd = f"--constraint {constraint}" if constraint else ""
 
     run_command(
-        f'pip3 wheel --disable-pip-version-check --progress-bar off --no-clean --no-binary "{skip_binary}" --wheel-dir {output} --find-links {index} {constraint_cmd} "{package}"',
+        f'pip3 wheel --disable-pip-version-check --progress-bar off --no-clean --no-binary "{skip_binary}" --wheel-dir {output} --extra-index-url {index} {constraint_cmd} "{package}"',
         env=build_env,
         timeout=timeout,
     )
@@ -54,7 +54,7 @@ def build_wheels_requirement(
     legacy_cmd = "--use-deprecated=legacy-resolver" if legacy else ""
 
     run_command(
-        f'pip3 wheel --disable-pip-version-check --progress-bar off {legacy_cmd} --no-clean --no-binary "{skip_binary}" --wheel-dir {output} --find-links {index} {constraint_cmd} --requirement {requirement}',
+        f'pip3 wheel --disable-pip-version-check --progress-bar off {legacy_cmd} --no-clean --no-binary "{skip_binary}" --wheel-dir {output} --extra-index-url {index} {constraint_cmd} --requirement {requirement}',
         env=build_env,
         timeout=timeout,
     )
@@ -72,7 +72,7 @@ def build_wheels_local(
     build_env["MAKEFLAGS"] = f"-j{cpu}"
 
     run_command(
-        f"pip3 wheel --disable-pip-version-check --progress-bar off --no-clean --wheel-dir {output} --find-links {index} .",
+        f"pip3 wheel --disable-pip-version-check --progress-bar off --no-clean --wheel-dir {output} --extra-index-url {index} .",
         env=build_env,
     )
 
@@ -123,5 +123,5 @@ def install_pips(index: str, pips: str) -> None:
     packages = " ".join(pips.split(";"))
 
     run_command(
-        f"pip install --disable-pip-version-check --progress-bar off --upgrade --no-cache-dir --prefer-binary --find-links {index} {packages}",
+        f"pip install --disable-pip-version-check --progress-bar off --upgrade --no-cache-dir --prefer-binary --extra-index-url {index} {packages}",
     )


### PR DESCRIPTION
Adjusts our Wheels builder to use the index instead of the find-links logic.