### PR TITLE
Add Alpine 3.18 to known platforms

### DIFF
--- a/builder/wheel.py
+++ b/builder/wheel.py
@@ -31,6 +31,7 @@ _ARCH_PLAT = {
 _ALPINE_PLATFORM = {
     ("3", "16"): "musllinux_1_2",
     ("3", "17"): "musllinux_1_2",
+    ("3", "18"): "musllinux_1_2",
 }
 
 


### PR DESCRIPTION
I assume it's still `musllinux_1_2`.
https://github.com/home-assistant/core/actions/runs/6435311230/job/17476299753#step:5:322

/CC @frenck