### PR TITLE
Remove cchardet from tests, we don't use it anymore

### DIFF
--- a/requirements_wheels_test.txt
+++ b/requirements_wheels_test.txt
@@ -1,4 +1,3 @@
 requests==2.31.0
-cchardet==2.1.7
 Brotli==1.1.0
 orjson==3.9.7


### PR DESCRIPTION
SSIA

We've moved to faust-cchardet (for which we don't need to test wheels).