### PR TITLE
Fix numpy install (3.12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,20 @@ RUN \
     && if [ "${BUILD_ARCH}" = "i386" ]; then \
         export NPY_DISABLE_SVML=1; \
     fi \
+    && if [ "${CPYTHON_ABI}" = "cp312" ] && [ "${BUILD_ARCH}" != "amd64" ]; then \
+        apk add --no-cache --virtual .build-dependencies2 \
+            openblas-dev \
+        && pip3 install --no-cache-dir \
+            --extra-index-url "https://wheels.home-assistant.io/musllinux-index/" \
+            git+https://github.com/scikit-build/ninja-python-distributions.git@89b1a02be6b47919c4da3daad06f2a020a16cc7f \
+        && pip3 install --no-cache-dir \
+            --extra-index-url "https://wheels.home-assistant.io/musllinux-index/" \
+            Cython packaging patchelf pyproject-metadata setuptools \
+        && pip3 install --no-cache-dir \
+            --no-build-isolation \
+            --extra-index-url "https://wheels.home-assistant.io/musllinux-index/" \
+            $(cat /usr/src/requirements_${CPYTHON_ABI}.txt | grep numpy); \
+    fi \
     && pip3 install --no-cache-dir \
         -r /usr/src/requirements.txt \
         -r /usr/src/requirements_${CPYTHON_ABI}.txt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY \
     requirements_${CPYTHON_ABI}.txt \
     /usr/src/
 RUN \
-    set -x \
+    set -xo pipefail \
     && apk add --no-cache \
         rsync \
         openssh-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,15 @@ ARG \
 
 WORKDIR /usr/src
 
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
+
 # Install requirements
 COPY \
     requirements.txt \
     requirements_${CPYTHON_ABI}.txt \
     /usr/src/
 RUN \
-    set -xo pipefail \
-    && apk add --no-cache \
+    apk add --no-cache \
         rsync \
         openssh-client \
         patchelf \


### PR DESCRIPTION
This should work to get `numpy` build with Python 3.12.

A bit more involved than usual, but until https://github.com/scikit-build/ninja-python-distributions/issues/220 is resolved, `ninja` needs to be build from git directly unfortunately.

/CC @frenck