### PR TITLE
Cleanup numpy install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,17 +36,7 @@ RUN \
     fi \
     && if [ "${CPYTHON_ABI}" = "cp312" ] && [ "${BUILD_ARCH}" != "amd64" ]; then \
         apk add --no-cache --virtual .build-dependencies2 \
-            openblas-dev \
-        && pip3 install --no-cache-dir \
-            --extra-index-url "https://wheels.home-assistant.io/musllinux-index/" \
-            git+https://github.com/scikit-build/ninja-python-distributions.git@89b1a02be6b47919c4da3daad06f2a020a16cc7f \
-        && pip3 install --no-cache-dir \
-            --extra-index-url "https://wheels.home-assistant.io/musllinux-index/" \
-            Cython packaging patchelf pyproject-metadata setuptools \
-        && pip3 install --no-cache-dir \
-            --no-build-isolation \
-            --extra-index-url "https://wheels.home-assistant.io/musllinux-index/" \
-            $(cat /usr/src/requirements_${CPYTHON_ABI}.txt | grep numpy); \
+            openblas-dev; \
     fi \
     && pip3 install --no-cache-dir \
         -r /usr/src/requirements.txt \


### PR DESCRIPTION
Now that https://github.com/scikit-build/ninja-python-distributions/issues/220 is fixed, we can remove the custom build steps for `numpy`.

Additionally, I have started building the 3.12 wheels over in the core repo and the numpy ones for musllinux are up on https://wheels.home-assistant.io/musllinux/. This brings to build times back down in the range of 1-5min per job.

_Verified that the publish job would success, so it's safe to start a new release after this one._
https://github.com/cdce8p/wheels/actions/runs/6463289052

/CC @frenck