### PR TITLE
Update numpy to 1.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Version of system builds:
 
 - GCC 12.2.1
 - Cython 3.0.3
-- numpy 1.24.2
+- numpy 1.26.0
 - scikit-build 0.17.1
 - cffi 1.16.0
 

--- a/requirements_cp311.txt
+++ b/requirements_cp311.txt
@@ -1,4 +1,4 @@
 Cython==3.0.3
-numpy==1.24.2
+numpy==1.26.0
 scikit-build==0.17.6
 cffi==1.16.0


### PR DESCRIPTION
We already use `1.26.0` for Python 3.12, start using it for 3.11 as well.
That's the same version that's pinned by core for both 3.11 and 3.12.

This further improves the build times. The previous version `1.24.2` wasn't cached for some 3.11 platforms.
https://wheels.home-assistant.io/musllinux/

Full run: https://github.com/cdce8p/wheels/actions/runs/6466414134