### PR TITLE
Add requirements from base image to wheels test file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           abi: ${{ matrix.abi }}
           tag: ${{ matrix.tag }}
           arch: ${{ matrix.arch }}
-          apk: "libffi-dev;openssl-dev"
+          apk: "mariadb-dev;postgresql-dev;libffi-dev;openssl-dev"
           skip-binary: "orjson"
           env-file: True
           test: True

--- a/requirements_wheels_test.txt
+++ b/requirements_wheels_test.txt
@@ -1,3 +1,6 @@
 requests==2.31.0
 Brotli==1.1.0
 orjson==3.9.10
+faust-cchardet==2.1.19
+mysqlclient==2.2.1
+psycopg2==2.9.9


### PR DESCRIPTION
This PR adds all requirements from our base image to our Wheels builder as well:

Ref: <https://github.com/home-assistant/docker/blob/master/requirements.txt>

This ensures we always test against these, as they are not tested/triggered anywhere else. It helps working around chicken/egg problems and ensure these can be build (as Core doesn't run it).



