### PR TITLE
Add Alpine 3.19 platform to the Wheels builder

### DIFF
--- a/builder/wheel.py
+++ b/builder/wheel.py
@@ -32,6 +32,7 @@ _ALPINE_PLATFORM = {
     ("3", "16"): "musllinux_1_2",
     ("3", "17"): "musllinux_1_2",
     ("3", "18"): "musllinux_1_2",
+    ("3", "19"): "musllinux_1_2",
 }
 
 


### PR DESCRIPTION
Noticed as the CI was failing here: <https://github.com/home-assistant/wheels/actions/runs/7420881519/job/20193096639>