### PR TITLE
Stop building Python 3.11 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        abi: ["cp311", "cp312"]
+        abi: ["cp312"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,10 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        abi: ["cp311", "cp312"]
+        abi: ["cp312"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
         include:
-          - abi: cp311
-            tag: musllinux_1_2
-            base: 3.11-alpine3.19
           - abi: cp312
             tag: musllinux_1_2
             base: 3.12-alpine3.19

--- a/requirements_cp311.txt
+++ b/requirements_cp311.txt
@@ -1,4 +1,0 @@
-Cython==3.0.9
-numpy==1.26.0
-scikit-build==0.17.6
-cffi==1.16.0


### PR DESCRIPTION
Noticed we are still building the Python 3.11 wheels here, which is no longer needed.