### PR TITLE
feat: add marisa-trie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests==2.31.0
 wheel==0.43.0
 setuptools==69.5.1
 pip==24.0
+marisa-trie==1.1.1


### PR DESCRIPTION
We have a small local catastrophe in one of custom components. 3.12 upgrade left us without per-compiled wheel for `marisa-trie`.
https://github.com/DurgNomis-drol/ha_toyota/issues/258

I did fix that with cross-system QEMU build for `aarch64`, but `armv?l` is not supported by that.
https://github.com/pytries/marisa-trie/pull/101
https://github.com/pytries/marisa-trie/pull/102
https://github.com/piwheels/piwheels/issues/346

Maybe this is the correct place to provide a wheel for 32-bit Raspberries?
