### PR TITLE
Normalize package names

### DIFF
--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -207,7 +207,7 @@ def builder(
             constraints = parse_requirements(constraint) if constraint else []
             remove_local_wheels(
                 package_index,
-                skip_binary.split(";"),
+                skip_binary,
                 packages + constraints,
                 wheels_dir,
             )

--- a/builder/infra.py
+++ b/builder/infra.py
@@ -51,7 +51,7 @@ def create_wheels_list(base_index: str) -> str:
 def create_package_map(packages: list[str]) -> dict[str, AwesomeVersion]:
     """Create a dictionary from package base name to package and version string."""
     results: dict[str, AwesomeVersion] = {}
-    for package in packages.copy():
+    for package in packages:
         find = _RE_REQUIREMENT.match(package)
         if not find:
             continue
@@ -84,7 +84,7 @@ def check_existing_packages(
     package_index: dict[str, list[WhlPackage]], package_map: dict[str, AwesomeVersion]
 ) -> set[str]:
     """Return the set of package names that already exist in the index."""
-    found: set[str] = set({})
+    found: set[str] = set()
     for package, version in package_map.items():
         if package in package_index and any(
             sub_package.version == version for sub_package in package_index[package]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ click-pathlib==2020.3.13.0
 requests==2.32.3
 wheel==0.44.0
 setuptools==75.3.0
+packaging==24.1
 pip==24.3.1

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -10,7 +10,7 @@ def test_extract_packages_from_index() -> None:
     package_index = infra.extract_packages_from_index("https://example.com")
     assert list(package_index.keys()) == [
         "aiohttp",
-        "google_cloud_pubsub",
+        "google-cloud-pubsub",
         "grpcio",
         "aioconsole",
     ]

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -145,6 +145,31 @@ def test_check_available_binary_for_missing_constraint() -> None:
     )
 
 
+def test_check_available_binary_normalized_package_names() -> None:
+    """Test package names are normalized before checking package index."""
+    package_index = infra.extract_packages_from_index("https://example.com")
+    assert list(package_index.keys()) == [  # normalized spelling from index
+        "aiohttp",
+        "google-cloud-pubsub",
+        "grpcio",
+        "aioconsole",
+    ]
+    assert (
+        infra.check_available_binary(
+            package_index,
+            "AIOhttp;GRPcio",
+            packages=[
+                "aioHTTP==3.7.4",
+                "google_cloud-PUBSUB==2.1.0",
+            ],
+            constraints=[
+                "grpcIO==1.31.0",  # Already exists in index
+            ],
+        )
+        == ":none:"
+    )
+
+
 def test_remove_local_wheel(tmppath: Path) -> None:
     """Test removing an existing wheel."""
     package_index = infra.extract_packages_from_index("https://example.com")
@@ -153,8 +178,13 @@ def test_remove_local_wheel(tmppath: Path) -> None:
     p.touch()
     p = tmppath / "grpcio-1.31.0-cp310-cp310-musllinux_1_2_x86_64.whl"
     p.touch()
+    p = tmppath / "grpcio-1.31.0-py3-none-any.whl"  # different platform tag
+    p.touch()
+    p = tmppath / "some_other_file.txt"  # other files are ignored
+    p.touch()
     assert {p.name for p in tmppath.glob("*.whl")} == {
         "grpcio-1.31.0-cp310-cp310-musllinux_1_2_x86_64.whl",
+        "grpcio-1.31.0-py3-none-any.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
 
@@ -168,7 +198,7 @@ def test_remove_local_wheel(tmppath: Path) -> None:
         wheels_dir=tmppath,
     )
 
-    # grpcio is removed
+    # both grpcio wheels are removed
     assert {p.name for p in tmppath.glob("*.whl")} == {
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
@@ -202,3 +232,30 @@ def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
         "grpcio-1.43.0-cp310-cp310-musllinux_1_2_x86_64.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
+
+
+def test_remove_local_wheel_normalized_package_names(tmppath: Path) -> None:
+    """Test package names are normalized before removing existing wheels."""
+    package_index = infra.extract_packages_from_index("https://example.com")
+
+    p = tmppath / "google_cloud_pubsub-2.1.0-py2.py3-none-any.whl"
+    p.touch()
+    p = tmppath / "grpcio-1.31.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+    p.touch()
+    assert {p.name for p in tmppath.glob("*.whl")} == {
+        "grpcio-1.31.0-cp310-cp310-musllinux_1_2_x86_64.whl",
+        "google_cloud_pubsub-2.1.0-py2.py3-none-any.whl",
+    }
+
+    infra.remove_local_wheels(
+        package_index,
+        skip_exists="GRPcio;GOOGLE-cloud_pubsub",
+        packages=[
+            "google_cloud-PUBSUB==2.1.0",  # Exists in index
+            "grpcIO==1.31.0",  # Exists in index
+        ],
+        wheels_dir=tmppath,
+    )
+
+    # grpcio and google-cloud-pubsub are removed
+    assert {p.name for p in tmppath.glob("*.whl")} == set()

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -160,7 +160,7 @@ def test_remove_local_wheel(tmppath: Path) -> None:
 
     infra.remove_local_wheels(
         package_index,
-        skip_exists=["grpcio"],
+        skip_exists="grpcio",
         packages=[
             "google_cloud_pubsub==2.9.0",
             "grpcio==1.31.0",  # Exists in index
@@ -189,7 +189,7 @@ def test_remove_local_wheel_preserves_newer(tmppath: Path) -> None:
 
     infra.remove_local_wheels(
         package_index,
-        skip_exists=["grpcio"],
+        skip_exists="grpcio",
         packages=[
             "google_cloud_pubsub==2.9.0",
             "grpcio==1.43.0",  # Newer than index


### PR DESCRIPTION
Noticed that some wheels are always build and uploaded even though the current version already exists on https://wheels.home-assistant.io/musllinux/. Notably `charset-normalizer` and `pymicro-vad`. The reason for it is that the package name in the constraints file doesn't match the wheel name spelling => `-` vs `_`.


```
# package_constraints.txt
charset-normalizer==3.4.0
pymicro-vad==1.0.1

# wheel index
charset_normalizer-3.4.0-py3-none-any.whl
pymicro_vad-1.0.1-cp312-cp312-musllinux_1_2_x86_64.whl
```

This PR uses `packaging` to normalize the package names and prevent duplicate wheel builds and uploads.

https://github.com/home-assistant/core/actions/runs/11683262865/job/32532124722#step:12:2598