### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,9 @@ jobs:
     name: Test wheels ${{ matrix.arch }}-${{ matrix.abi }}-${{ matrix.tag }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        abi: ["cp312"]
+        abi: ["cp312", "cp313"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,16 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        abi: ["cp312"]
+        abi: ["cp312", "cp313"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
         include:
           - abi: cp312
             tag: musllinux_1_2
             base: 3.12-alpine3.20
+          - abi: cp313
+            tag: musllinux_1_2
+            base: 3.13-alpine3.20
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4.2.2

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ Version of system builds:
 - scikit-build 0.18.1
 - cffi 1.17.1
 
+### Python 3.13 / musllinux_1_2
+
+Build with Alpine 3.20
+Images: ghcr.io/home-assistant/wheels/ARCH/musllinux_1_2/cp313:VERSION
+
+Version of system builds:
+
+- GCC 13.2.1
+- Cython 3.0.11
+- numpy 2.1.2
+- scikit-build 0.18.1
+- cffi 1.17.1
+
 
 ## Misc
 

--- a/requirements_cp313.txt
+++ b/requirements_cp313.txt
@@ -1,0 +1,4 @@
+Cython==3.0.11
+numpy==2.1.2
+scikit-build==0.18.1
+cffi==1.17.1


### PR DESCRIPTION
Waiting on a new release of `docker-base` with Python 3.13. https://github.com/home-assistant/docker-base