### PR TITLE
Update numpy to 2.1.3

### DIFF
--- a/requirements_cp312.txt
+++ b/requirements_cp312.txt
@@ -1,4 +1,4 @@
 Cython==3.0.11
-numpy==2.1.2
+numpy==2.1.3
 scikit-build==0.18.1
 cffi==1.17.1

--- a/requirements_cp313.txt
+++ b/requirements_cp313.txt
@@ -1,4 +1,4 @@
 Cython==3.0.11
-numpy==2.1.2
+numpy==2.1.3
 scikit-build==0.18.1
 cffi==1.17.1


### PR DESCRIPTION
Core was updated to `2.1.3` today: https://github.com/home-assistant/core/pull/130191.