### PR TITLE
Remove grpc environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,6 @@ jobs:
         shell: bash
         run: |
           (
-            echo "GRPC_BUILD_WITH_BORING_SSL_ASM=false"
-            echo "GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true"
-            echo "GRPC_PYTHON_BUILD_WITH_CYTHON=true"
             echo "CARGO_NET_GIT_FETCH_WITH_CLI=true"
           ) > .env_file
 


### PR DESCRIPTION
`grpcio` is not part of the test wheel build.
https://github.com/home-assistant/wheels/blob/837cf9f7edb4a1136dff1db618b152cc4e4b5bc9/requirements_wheels_test.txt#L1-L6