### PR TITLE
Build common wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,37 @@
+name: Build wheels
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/build-wheels.yml"
+      - "requirements_wheels.txt"
+
+jobs:
+  wheels:
+    name: Build basic wheels
+    if: github.repository_owner == 'home-assistant'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: ["cp312", "cp313"]
+        arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.2.2
+
+      - name: Build wheels
+        uses: ./
+        with:
+          abi: ${{ matrix.abi }}
+          tag: musllinux_1_2
+          arch: ${{ matrix.arch }}
+          wheels-key: ${{ secrets.WHEELS_KEY }}
+          apk: "mariadb-dev;postgresql-dev;libffi-dev;openblas-dev"
+          skip-binary: "cython"
+          requirements: "requirements_wheels.txt"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2
 
+      - name: Pull-Request test
+        id: test
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "is_test=True" >> $GITHUB_OUTPUT
+          else
+            echo "is_test=False" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build wheels
         uses: ./
         with:
@@ -32,6 +42,7 @@ jobs:
           tag: musllinux_1_2
           arch: ${{ matrix.arch }}
           wheels-key: ${{ secrets.WHEELS_KEY }}
+          test: ${{ steps.test.outputs.is_test }}
           apk: "mariadb-dev;postgresql-dev;libffi-dev;openblas-dev"
           skip-binary: "cython"
           requirements: "requirements_wheels.txt"

--- a/requirements_wheels.txt
+++ b/requirements_wheels.txt
@@ -1,0 +1,6 @@
+cffi==1.17.1
+cython==3.0.11
+mysqlclient==2.2.6
+ninja==1.11.1.1
+numpy==2.1.3
+psycopg2==2.9.10


### PR DESCRIPTION
An alternative approach to
- https://github.com/home-assistant/core/pull/126987.

By building wheels for common build dependencies, we can speed up the normal wheel build significantly. Without it, pip would create those wheel when installing the isolated build environments for dependencies, however those aren't cached / uploaded to wheels.home-assistant.io. Thus the wheel build would be run for each new dependency.

It's so slow otherwise, that I've resorted to building the build dependencies manually to speed up the process. The difference can also be seen in the action logs here right after the Python 3.13 update was merged.
**Without wheels**: 44min (https://github.com/home-assistant/wheels/actions/runs/11750225112)
**With**: 4:21min (https://github.com/home-assistant/wheels/actions/runs/11755288486)

If this PR is merged, each dependabot PR to the requirements file would automatically trigger the wheel build and ensure those are uploaded / available for subsequent builds.

The `home-assistant/docker` repo implements parts of it as well. However only for the Python version used for the image, i.e. `cp313` currently. https://github.com/home-assistant/docker/blob/2024.11.0/.github/workflows/builder.yml#L62-L71

> [!important]
> The `WHEELS_KEY` secret needs to be added to the repo.