### PR TITLE
Add check if QEMU is actually required to build wheels

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,14 @@ runs:
         echo "path=$data_path" >> $GITHUB_OUTPUT
 
     - shell: bash
+      id: host-info
+      run: |
+        echo "host-machine=$(uname -m)" >> $GITHUB_OUTPUT
+
+    - shell: bash
+      if: |
+        steps.host-info.outputs.host-machine == 'x86_64'
+        && !(matrix.arch == 'amd64' || matrix.arch == 'i386')
       run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 


### PR DESCRIPTION
We setup multiarch by default currently. Typically GitHub Action runners are x86_64 machines. `multiarch/qemu-user-static` only supports `linux/amd64`. For some existing target architectures QEMU is not even needed (amd64 and i386 to be specific).

Also, this prevents using `aarch64` builder. Since currently `multiarch/qemu-user-static` does not support `aarch64` host machines, simply skip setup in that case.