### PR TITLE
Support wheels builds with older musl versions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,13 @@ def sys_alpine():
         yield
 
 
+@pytest.fixture(autouse=True)
+def sys_musl_version():
+    """Patch alpine musl version lookup table."""
+    with patch("builder.wheel._ALPINE_MUSL_VERSION", new={("3", "16"): (1, 2)}):
+        yield
+
+
 @pytest.fixture
 def tmppath(tmpdir):
     return Path(tmpdir)

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -64,7 +64,11 @@ def test_linux_regex_wrong(test):
     "abi,platform",
     [
         ("cp310", "musllinux_1_2_x86_64"),
+        ("cp310", "musllinux_1_1_x86_64"),
+        ("cp310", "musllinux_1_0_x86_64"),
         ("abi3", "musllinux_1_2_x86_64"),
+        ("abi3", "musllinux_1_1_x86_64"),
+        ("abi3", "musllinux_1_0_x86_64"),
         ("none", "any"),
     ],
 )
@@ -78,8 +82,8 @@ def test_working_abi_platform(abi, platform):
     [
         ("cp311", "musllinux_1_2_x86_64"),
         ("cp310", "musllinux_1_2_i686"),
-        ("cp310", "musllinux_1_1_x86_64"),
-        ("abi3", "musllinux_1_1_x86_64"),
+        ("cp310", "musllinux_1_3_x86_64"),
+        ("abi3", "musllinux_1_3_x86_64"),
     ],
 )
 def test_not_working_abi_platform(abi, platform):
@@ -92,10 +96,10 @@ def test_fix_wheel_unmatch(tmppath: Path) -> None:
 
     p = tmppath / "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl"
     p.touch()
-    p = tmppath / "grpcio-1.31.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+    p = tmppath / "grpcio-1.31.0-cp39-cp39-musllinux_1_1_x86_64.whl"
     p.touch()
     assert {p.name for p in tmppath.glob("*.whl")} == {
-        "grpcio-1.31.0-cp310-cp310-musllinux_1_1_x86_64.whl",
+        "grpcio-1.31.0-cp39-cp39-musllinux_1_1_x86_64.whl",
         "google_cloud_pubsub-2.9.0-py2.py3-none-any.whl",
     }
 


### PR DESCRIPTION
Minor musl versions are backwards compatible. E.g. if a package builds its binaries for `musllinux_1_1`, they can still be installed on `musllinux_1_2` or newer. This can be seen when checking the output of `pip debug` as well.
```bash
docker run -it --rm ghcr.io/home-assistant/aarch64-base-python:3.13-alpine3.21 bash
  pip debug
```

```py
Compatible tags: 132
  cp313-cp313-musllinux_1_2_aarch64
  cp313-cp313-musllinux_1_1_aarch64
  cp313-cp313-musllinux_1_0_aarch64
  ...
```

By updating the platform check logic, we can prevent unnecessary builds and reuse more (potentially) existing wheels from PyPI.

--
This would have prevented an issue a few days ago where the wheel builder was for some reason (probably insufficient memory) unable to build `awscrt-0.24.1-cp313-abi3-musllinux_1_2_aarch64`, even though they upload a `musllinux_1_1_aarch64` wheel to PyPI which could have been used instead.