### PR TITLE
Fix syntax warning in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG \
     CPYTHON_ABI \
     QEMU_CPU \
     AUDITWHEEL_VERSION=6.2.0 \
-    PIP_EXTRA_INDEX_URL=https://wheels.home-assistant.io/musllinux-index/ \
+    PIP_EXTRA_INDEX_URL=https://wheels.home-assistant.io/musllinux-index/
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
```
1 warning found (use docker --debug to expand):
- Empty continuation line found in: ARG     BUILD_ARCH     CPYTHON_ABI     QEMU_CPU     AUDITWHEEL_VERSION=6.2.0   
    PIP_EXTRA_INDEX_URL=https://wheels.home-assistant.io/musllinux-index/ WORKDIR /usr/src
```