### PR TITLE
Update numpy to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Version of system builds:
 
 - GCC 14.2.0
 - Cython 3.1.2
-- numpy 2.2.2
+- numpy 2.3.0
 - scikit-build 0.18.1
 - cffi 1.17.1
 

--- a/requirements_cp313.txt
+++ b/requirements_cp313.txt
@@ -1,4 +1,4 @@
 Cython==3.1.2
-numpy==2.2.2
+numpy==2.3.0
 scikit-build==0.18.1
 cffi==1.17.1


### PR DESCRIPTION
https://github.com/numpy/numpy/releases/tag/v2.3.0

Related core PR:
- https://github.com/home-assistant/core/pull/146296