### PR TITLE
Work around OpenSSL mismatch in Alpine 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ COPY \
     requirements_${CPYTHON_ABI}.txt \
     /usr/src/
 RUN \
-    apk add --no-cache \
+    apk upgrade --no-cache \
+    && apk add --no-cache \
         rsync \
         openssh-client \
         patchelf \


### PR DESCRIPTION
Our wheels building is currently failing with:

```
OpenSSL version mismatch. Built against 30500000, you have 3050003f

rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: unexplained error (code 255) at io.c(232) [sender=3.4.1]
```

This is causing our beta release to blocked right now, as required wheels are missing on the wheels server.

This PR updates Alpine on the fly, to ensure all packages (including the already installed OpenSSL package) are up to date to address the mismatch right now.

Potential ref: https://gitlab.alpinelinux.org/alpine/aports/-/issues/17547 

PS: For the future, we shouldn't be installing this stuff on the fly maybe... 😬 