### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        abi: ["cp313"]
+        abi: ["cp313", "cp314"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
+        exclude:
+          - abi: cp314
+            arch: armhf
+          - abi: cp314
+            arch: armv7
+          - abi: cp314
+            arch: i386
 
     steps:
       - name: Check out code from GitHub

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,23 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        abi: ["cp313"]
+        abi: ["cp313", "cp314"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
         include:
           - abi: cp313
             tag: musllinux_1_2
             base: 3.13-alpine3.22
+          - abi: cp314
+            tag: musllinux_1_2
+            base: 3.14-alpine3.22
+        exclude:
+          - abi: cp314
+            arch: armhf
+          - abi: cp314
+            arch: armv7
+          - abi: cp314
+            arch: i386
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v5.0.0

--- a/README.md
+++ b/README.md
@@ -22,10 +22,23 @@ Images: ghcr.io/home-assistant/wheels/ARCH/musllinux_1_2/cp313:VERSION
 Version of system builds:
 
 - GCC 14.2.0
-- Cython 3.1.2
+- Cython 3.1.4
 - numpy 2.3.3
 - scikit-build 0.18.1
-- cffi 1.17.1
+- cffi 2.0.0
+
+### Python 3.14 / musllinux_1_2
+
+Build with Alpine 3.22
+Images: ghcr.io/home-assistant/wheels/ARCH/musllinux_1_2/cp314:VERSION
+
+Version of system builds:
+
+- GCC 14.2.0
+- Cython 3.1.4
+- numpy 2.3.3
+- scikit-build 0.18.1
+- cffi 2.0.0
 
 
 ## Misc

--- a/requirements_cp314.txt
+++ b/requirements_cp314.txt
@@ -1,0 +1,4 @@
+Cython==3.1.4
+numpy==2.3.3
+scikit-build==0.18.1
+cffi==2.0.0


### PR DESCRIPTION
Depends on the base image build for `2025.10.1`.
https://github.com/home-assistant/docker-base/actions/runs/18505320128

**Update**: Done