### PR TITLE
Override skip binary for HA wheels

### DIFF
--- a/builder/__main__.py
+++ b/builder/__main__.py
@@ -58,7 +58,9 @@ _OVERRIDE_SKIP_BINARY = {
 @click.option("--pip", type=str, help="PiPy modules needed to build this.")
 @click.option("--index", required=True, help="Index URL of remote wheels repository.")
 @click.option(
-    "--skip-binary", default=_DEFAULT_SKIP_BINARY, help="List of packages to skip wheels from pypi."
+    "--skip-binary",
+    default=_DEFAULT_SKIP_BINARY,
+    help="List of packages to skip wheels from pypi.",
 )
 @click.option(
     "--requirement",
@@ -119,7 +121,9 @@ def builder(
     check_url(index)
     if (override := _OVERRIDE_SKIP_BINARY.get(index)) is not None:
         if skip_binary != _DEFAULT_SKIP_BINARY:
-            print("WARNING: Skip binary will be ignored as override exists for this index.")
+            print(
+                "WARNING: Skip binary will be ignored as override exists for this index."
+            )
         skip_binary = ";".join(override)
         print(f"Setting skip binary to: {skip_binary}")
 


### PR DESCRIPTION
`https://wheels.home-assistant.io` is our default index and it will be used throughout our organisation in different repos like [core](https://github.com/home-assistant/core), [docker](https://github.com/home-assistant/docker), [supervisor](https://github.com/home-assistant/supervisor/), [wheels-custom-integrations](https://github.com/home-assistant/wheels-custom-integrations). To avoid that some repo accidentally is uploading a wheel from pypi, we defined a global skip binary list per index