### PR TITLE
Use docker action to publish image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           context: . # So action will not pull the repository again
           push: ${{ github.event_name != 'pull_request' }}
+          pull: true
           platforms: ${{ matrix.platform }}
           cache-from: type=registry,ref=${{ steps.info.outputs.name }}:dev
           build-args: |


### PR DESCRIPTION
Additionally pusblish also a tagged imaged with the commit sha

Use arm runner for aarch64 images to increase build speed:

<table>
<tr>
 <td>Jobs
 <td>Before
 <td>After
<tr>
 <td>(cp313, musllinux_1_2, aarch64) 
 <td>2m 57s
 <td>1m 12s
<tr>
 <td>(cp314, musllinux_1_2, aarch64) 
 <td>3m 13s
 <td>1m 12s
</table>
Did not switch for deprecated archs as it would require testing and we are removing it anyways in a few weeks