### PR TITLE
Use arm runner for aarch64 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,17 @@ jobs:
 
   test:
     name: Test wheels ${{ matrix.arch }}-${{ matrix.abi }}-${{ matrix.tag }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         abi: ["cp313", "cp314"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "armhf", "armv7", "amd64", "i386"]
+        include:
+          - runs-on: ubuntu-latest
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
         exclude:
           - abi: cp314
             arch: armhf


### PR DESCRIPTION
Currently, we use an amd64 runner with QEMU to build the aarch64 image. The QEMU aarch64 slows down the build process since it needs to simulate the aarch64 arch. GitHub has a native ARM runner, which can be used to build the aarch64 image natively without the need of QEMU

<table>
<tr>
 <td>Jobs
 <td>Before
 <td>After
<tr>
 <td>aarch64-cp313-musllinux_1_2 
 <td>1m 4s
 <td>38s
<tr>
 <td>aarch64-cp314-musllinux_1_2
 <td>3m 22s
 <td>50s 
</table>