### PR TITLE
Consistently copy output wheels when `local-wheels-repo-path` is used

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -202,7 +202,7 @@ runs:
     - shell: bash
       if: ${{ inputs.local-wheels-repo-path }}
       run: |
-        docker cp "${{ inputs.name }}:/data/output" "${{ inputs.local-wheels-repo-path }}"
+        docker cp "${{ inputs.name }}:/data/output/." "${{ inputs.local-wheels-repo-path }}"
 
     - shell: bash
       run: |


### PR DESCRIPTION
The `docker cp` is not idemponent when copying a directory from the source and the destination directory doesn't exist on the first run. By adding a trailing dot, we explicitly copy content of the directory to the target.