### PR TITLE
builder: wheel.py: also try build_arch() when not in _ARCH_PLAT dict

### DIFF
--- a/builder/wheel.py
+++ b/builder/wheel.py
@@ -25,7 +25,6 @@ _RE_MUSLLINUX_PLATFORM: Final = re.compile(
 
 _ARCH_PLAT = {
     "amd64": "x86_64",
-    "aarch64": "aarch64",
 }
 
 _ALPINE_MUSL_VERSION = {
@@ -52,7 +51,7 @@ def sys_platform(arch: str) -> set[str]:
 
 def check_abi_platform(abi: str, platform: str) -> bool:
     """Return True if abi and platform work."""
-    arch = _ARCH_PLAT[build_arch()]
+    arch = _ARCH_PLAT.get(build_arch(), build_arch())
     sys_abi = build_abi()
 
     # Check platform
@@ -114,7 +113,7 @@ def run_auditwheel(wheels_folder: Path) -> bool:
                 wheel_file.unlink()
 
         # Copy back wheels & make sure ARCH is correct
-        target_arch = _ARCH_PLAT[build_arch()]
+        target_arch = _ARCH_PLAT.get(build_arch(), build_arch())
         for wheel_file in Path(temp_dir).glob("*.whl"):
             package = _RE_MUSLLINUX_PLATFORM.search(wheel_file.name)
             if not package:

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -1,6 +1,7 @@
 """Tests for pip module."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -88,6 +89,19 @@ def test_working_abi_platform(abi: str, platform: str) -> None:
 def test_not_working_abi_platform(abi: str, platform: str) -> None:
     """Test not working abi/platform variations."""
     assert not wheel.check_abi_platform(abi, platform)
+
+
+@pytest.mark.parametrize(
+    ("arch", "platform"),
+    [
+        ("amd64", "musllinux_1_2_x86_64"),
+        ("aarch64", "musllinux_1_2_aarch64"),
+    ],
+)
+def test_build_arch_platform_mapping(arch: str, platform: str) -> None:
+    """Test build arch maps to expected wheel platform arch."""
+    with patch("builder.wheel.build_arch", return_value=arch):
+        assert wheel.check_abi_platform("cp310", platform)
 
 
 def test_fix_wheel_unmatch(tmp_path: Path) -> None:


### PR DESCRIPTION
There is existing error handling when the arch is not valid for the wheels platform, and so the hard-coded substitution lookup by a dynamic input value may fail code execution prematurely with a key error.

Let's also try the dynamic value itself which is known to also be valid in some supported configurations:

* When key not found in lookup of platform architecture substitution dict _ARCH_PLAT{} then try again with expected architecture specifier build_arch().
* Remove now-redundant "aarch64" key/value pair from platform architecture substitution. The expected architecture specifier does not need substitution here.

In unsupported configurations this can then also be successful (or not), and with the more descriptive error message output informing the user by allowing the existing error handling to be exercised.