### PR TITLE
Bump distro version to Alpine 3.23 et. al

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
   "name": "Wheels",
-  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "image": "mcr.microsoft.com/devcontainers/python:3.14",
   "postStartCommand": "pip install -r requirements.txt -r requirements_tests.txt && prek install",
   "customizations": {
     "vscode": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        abi: ["cp313", "cp314"]
+        abi: ["cp314"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "amd64"]
         include:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,14 +17,12 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        abi: ["cp313", "cp314"]
+        abi: ["cp314"]
         tag: ["musllinux_1_2"]
         arch: ["aarch64", "amd64"]
         include:
-          - abi: cp313
-            base: 3.13-alpine3.22
           - abi: cp314
-            base: 3.14-alpine3.22
+            base: 3.14-alpine3.23
 
           - arch: aarch64
             platform: linux/arm64

--- a/README.md
+++ b/README.md
@@ -14,30 +14,18 @@ Compile utilities:
 - automake
 - cargo
 
-### Python 3.13 / musllinux_1_2
-
-Build with Alpine 3.22
-Images: ghcr.io/home-assistant/wheels/ARCH/musllinux_1_2/cp313:VERSION
-
-Version of system builds:
-
-- GCC 14.2.0
-- Cython 3.2.2
-- numpy 2.3.3
-- scikit-build 0.18.1
-- cffi 2.0.0
-
 ### Python 3.14 / musllinux_1_2
 
-Build with Alpine 3.22
+Build with Alpine 3.23
 Images: ghcr.io/home-assistant/wheels/ARCH/musllinux_1_2/cp314:VERSION
 
 Version of system builds:
 
-- GCC 14.2.0
-- Cython 3.2.2
-- numpy 2.3.3
-- scikit-build 0.18.1
+- GCC 15.2.0
+- rust 1.91.1
+- Cython 3.2.5
+- numpy 2.4.4
+- scikit-build 0.19.0
 - cffi 2.0.0
 
 ## Misc

--- a/requirements_cp313.txt
+++ b/requirements_cp313.txt
@@ -1,4 +1,0 @@
-Cython==3.2.5
-numpy==2.3.3
-scikit-build==0.19.0
-cffi==2.0.0

--- a/requirements_cp314.txt
+++ b/requirements_cp314.txt
@@ -1,4 +1,4 @@
 Cython==3.2.5
-numpy==2.3.3
+numpy==2.4.4
 scikit-build==0.19.0
 cffi==2.0.0


### PR DESCRIPTION
Bump alpine distro version and update README.md to describe that and system
software versions. Notably:
- rust compiler stable version is now 1.91
- scikit-build is already the latest version but we update the README.md
with that information
- GCC gets a major verison bump to 15.2.0
- Cython has a patch level version bump 3.2.4 that partially readies some
compatibility features for the next minor version 3.3.x

Other notable changes:
- numpy version 2.4.4 (was 2.3.3) to align with alpine release EOL schedule
- bump devcontainer version Python 3.13 to Python 3.14
- drop Python 3.13 images from build (Python 3.14 is the default for
  3-months now since https://github.com/home-assistant/core/pull/161426)

Component orjson remains in skip-binary group due to upstream policy of
locking to latest stable rust release (home-assistant/wheels#1046) and this
is not available in Alpine 3.23 nor in any built toolchain

https://alpinelinux.org/posts/Alpine-3.23.0-released.html

Diff link (like on core PR) to upgraded packages: https://github.com/home-assistant/wheels/pull/1024/changes#diff-a4b9dc7b34a66b52170aa637f46870b42d6c433efe737920ead4769c492886d0