### PR TITLE
builder: utils.py print verbose information for run_command()

### DIFF
--- a/builder/utils.py
+++ b/builder/utils.py
@@ -1,5 +1,6 @@
 """Some utils for builder."""
 
+import inspect
 import os
 import subprocess
 import sys
@@ -41,6 +42,21 @@ def run_command(
     timeout: int | None = None,
 ) -> None:
     """Implement subprocess.run but handle timeout different."""
+    stack = inspect.stack()
+    print(
+        f"::group::"
+        f"{Path(*Path(stack[1].filename).parts[-2:])}:{stack[1].function}"
+        " => "
+        f"{Path(*Path(stack[0].filename).parts[-2:])}:{stack[0].function}"
+        "\n"
+        f"subprocess.run(\n"
+        f"    cmd={cmd},\n"
+        f"    env={'***' if env else env},\n"
+        f"    timeout={timeout}\n"
+        f")\n"
+        f"::endgroup::\n",
+    )
+
     subprocess.run(  # noqa: S602
         cmd,
         shell=True,


### PR DESCRIPTION
builder: utils.py print inspect information for run_command() as group
Let's expose inspect information about the caller and callee filename and
function name in the CI/CD output for wheels builder python runtime, and
the non-static arguments presented to subprocess.run()

* output is grouped instead of debug-only as a balance between verbosity
  and being noisy

* output gates printing env if not empty or None due to concerns about
  leaking secrets via env

* static arguments to subprocess.run() are not presented

Resolves: home-assistant/wheels#1036

Co-Authored-By: Robert Resch <robert@resch.dev>