### PR TITLE
Use action self-context repository to form the docker image name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -103,9 +103,11 @@ runs:
     - shell: bash
       id: pull
       run: |
-        name="ghcr.io/home-assistant/wheels/${{ inputs.arch }}/${{ inputs.tag }}/${{ inputs.abi }}:${{ steps.version.outputs.version }}"
+        name="ghcr.io/$ACTION_REPOSITORY/${{ inputs.arch }}/${{ inputs.tag }}/${{ inputs.abi }}:${{ steps.version.outputs.version }}"
         docker pull "$name"
         echo "name=$name" >> $GITHUB_OUTPUT
+      env:
+        ACTION_REPOSITORY: ${{ github.action_repository || github.repository }}
 
     - shell: bash
       id: options


### PR DESCRIPTION
action: use action self-context repository to form the docker image name

github.action_repository is imported to the env as ACTION_REPOSITORY
for a repository fork-friendly docker image reference.
github.repository is used instead when there is no action_repository as
when called from tests as a dotslash self-reference.