### PR TITLE
workflows: publish: give packages write permissions to github token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish:
     name: Publish builder
+    permissions:
+      packages: write
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: False


### PR DESCRIPTION
Update publish.yml to specify 'packages: write' permission needed by docker/build-push-action to upload packages properly. The alternative for personal GitHub accounts is to set additional write permissions for all workflows; this is not an option on organization GitHub accounts. With this applied the settings/actions/"Workflow permissions" may remain as selected "Read repository contents and packages permissions" instead of the more permissive "Read and write permissions" where available.