### PR TITLE
workflows: publish: info name specify docker image by github.repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - shell: bash
         id: info
         run: |
-          name="ghcr.io/home-assistant/wheels/${{ matrix.arch }}/${{ matrix.tag }}/${{ matrix.abi }}"
+          name="ghcr.io/${{ github.repository }}/${{ matrix.arch }}/${{ matrix.tag }}/${{ matrix.abi }}"
 
           version=$(echo "${{ github.ref }}" | awk -F"/" '{print $NF}' )
           if [ "${version}" = "master" ]; then


### PR DESCRIPTION
use github.repository variable instead of hard-coded "home-assistant/wheels" within info name in workflows/publish.yml