### PR TITLE
Upload wheels over Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The [wheels-server](https://github.com/home-assistant/wheels-server) is not
 publicly reachable — it accepts rsync uploads only over a Tailscale tailnet.
 The `tailscale-oauth-client-id` and `tailscale-oauth-secret` inputs are
 therefore required: the runner joins the tailnet as an ephemeral node (tagged
-`tag:ci` by default, override with `tailscale-tags`) before uploading to
-`wheels-host`:
+`tag:homeassistant-wheels-deploy-action` by default, override with
+`tailscale-tags`) before uploading to `wheels-host`:
 
 ```yaml
 - name: Build wheels

--- a/README.md
+++ b/README.md
@@ -39,6 +39,34 @@ $ python3 -m builder \
 
 - rsync
 
+## Uploading over Tailscale
+
+The [wheels-server](https://github.com/home-assistant/wheels-server) is not
+publicly reachable — it accepts rsync uploads only over a Tailscale tailnet.
+The `tailscale-oauth-client-id` and `tailscale-oauth-secret` inputs are
+therefore required: the runner joins the tailnet as an ephemeral node (tagged
+`tag:ci` by default, override with `tailscale-tags`) before uploading to
+`wheels-host`:
+
+```yaml
+- name: Build wheels
+  uses: home-assistant/wheels@2026.07.0
+  with:
+    abi: cp314
+    tag: musllinux_1_2
+    arch: amd64
+    wheels-key: ${{ secrets.WHEELS_KEY }}
+    wheels-host: wheels.<your-tailnet>.ts.net
+    tailscale-oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+    tailscale-oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+    requirements: "requirements.txt"
+```
+
+In test mode (`test: true`) and when publishing to a local folder
+(`local-wheels-repo-path`), nothing is uploaded and the runner does not join
+the tailnet. To publish to two servers during a migration, run the action
+twice (one step per host).
+
 ## Folder structure of index folder:
 
 `/musllinux/*`

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,15 @@ inputs:
   wheels-index:
     description: "The wheels index URL"
     default: "https://wheels.home-assistant.io"
+  tailscale-oauth-client-id:
+    description: "Tailscale OAuth client ID to join the tailnet the wheels host is on"
+    required: true
+  tailscale-oauth-secret:
+    description: "Tailscale OAuth client secret"
+    required: true
+  tailscale-tags:
+    description: "Comma-separated tailnet ACL tags for the ephemeral CI node"
+    default: "tag:ci"
   local-wheels-repo-path:
     description: "Path to a local folder to copy the repository to (wheels-host and wheels-user must be empty)"
     default: ""
@@ -79,6 +88,17 @@ runs:
           input="dev"
         fi
         echo "version=${input}" >> $GITHUB_OUTPUT
+
+    # The wheels host is only reachable over Tailscale — join the tailnet
+    # before ssh-keyscan/upload (ephemeral node, removed after the job).
+    # Skipped when nothing is uploaded (test mode or local folder).
+    - name: Connect to Tailscale
+      if: (inputs.test == 'false' || inputs.test == 'False') && inputs.local-wheels-repo-path == ''
+      uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
+      with:
+        oauth-client-id: ${{ inputs.tailscale-oauth-client-id }}
+        oauth-secret: ${{ inputs.tailscale-oauth-secret }}
+        tags: ${{ inputs.tailscale-tags }}
 
     - shell: bash
       run: |
@@ -164,6 +184,17 @@ runs:
           build+=("--remote \"${{ inputs.wheels-user }}@${{ inputs.wheels-host }}:${{ inputs.wheels-host-path }}\"")
         fi
 
+        # The upload runs inside the builder container, but Tailscale MagicDNS
+        # is only configured on the runner — resolve the wheels host here and
+        # inject it into the container via --add-host.
+        if [[ "${{ inputs.test }}" =~ false|False ]] && [ -z "${{ inputs.local-wheels-repo-path }}" ]; then
+          host_ip=$(getent ahostsv4 "${{ inputs.wheels-host }}" | awk '{print $1; exit}')
+          if [ -z "$host_ip" ]; then
+            echo "::error::Unable to resolve wheels host '${{ inputs.wheels-host }}' on the runner"
+            exit 1
+          fi
+          docker+=("--add-host ${{ inputs.wheels-host }}:$host_ip")
+        fi
 
         echo "build=${build[@]}" >> $GITHUB_OUTPUT
         echo "docker=${docker[@]}" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
     required: true
   tailscale-tags:
     description: "Comma-separated tailnet ACL tags for the ephemeral CI node"
-    default: "tag:ci"
+    default: "tag:homeassistant-wheels-deploy-action"
   local-wheels-repo-path:
     description: "Path to a local folder to copy the repository to (wheels-host and wheels-user must be empty)"
     default: ""


### PR DESCRIPTION
## Proposed change

The new [wheels-server](https://github.com/home-assistant/wheels-server) is not publicly reachable — it accepts rsync uploads only over a Tailscale tailnet. This makes the action upload over Tailscale:

- New **required** inputs `tailscale-oauth-client-id` and `tailscale-oauth-secret`, plus `tailscale-tags` (default `tag:homeassistant-wheels-deploy-action`). The runner joins the tailnet as an ephemeral node (via `tailscale/github-action`, pinned to v4.1.3) before uploading to `wheels-host`.
- The upload runs inside the builder container, but MagicDNS is only configured on the runner, so the wheels host is resolved on the runner and injected into the container with `--add-host`. Resolution failure fails the job with a clear error.
- The tailnet join and host resolution are skipped in test mode (`test: true`) and when publishing to a local folder (`local-wheels-repo-path`), since nothing is uploaded in those cases.
- README section documenting the setup, including running the action twice to publish to two servers during a migration.

## Type of change

- [ ] Bugfix
- [x] New feature
- [x] Breaking change
- [ ] Dependency upgrade